### PR TITLE
feat: handle binary buffers with `messageBuffer`

### DIFF
--- a/src/encoders/json_encoder.ts
+++ b/src/encoders/json_encoder.ts
@@ -12,7 +12,7 @@ export class JsonEncoder implements TransportEncoder {
     return JSON.stringify(message)
   }
 
-  decode(data: string) {
-    return JSON.parse(data)
+  decode(data: string | Buffer) {
+    return JSON.parse(data.toString())
   }
 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -27,7 +27,14 @@ export interface TransportConfig {
   retryQueue?: RetryQueueOptions
 }
 
-export interface RedisTransportConfig extends RedisOptions {}
+export interface RedisTransportConfig extends RedisOptions {
+  /**
+   * If true, we will use `messageBuffer` event instead of `message` event
+   * that is emitted by ioredis. `messageBuffer` will returns a buffer instead
+   * of a string and this is useful when you are dealing with binary data.
+   */
+  useMessageBuffer?: boolean
+}
 
 export interface Transport {
   setId: (id: string) => Transport
@@ -48,7 +55,7 @@ export interface TransportMessage<T extends Serializable = any> {
 
 export interface TransportEncoder {
   encode: (message: TransportMessage) => string | Buffer
-  decode: <T>(data: string) => { busId: string; payload: T }
+  decode: <T>(data: string | Buffer) => { busId: string; payload: T }
 }
 
 export interface RetryQueueOptions {


### PR DESCRIPTION
The issue is well described here: https://github.com/Julien-R44/bentocache/issues/19

Basically: when using a custom encoder which returns a buffer with binary data, then it will not work. because the `message` event emitted by ioredis automatically converts buffers

When dealing with binary data then `ioredis` recommends using the `messageBuffer` event: https://github.com/redis/ioredis?tab=readme-ov-file#pubsub

![image](https://github.com/boringnode/bus/assets/8337858/542cd0fe-2825-4c70-be06-1c792f1f63b6)

---

Suggested solution: when we create our bus with the redis transport, we can now pass the `useMessageBuffer` option which will make the bus listen on the `messageBuffer` event rather than `message`. 

```ts
const manager = new BusManager({
  transports: {
    redis: {
      transport: redis(
        {
          useMessageBuffer: true, // here
          host: 'localhost',
          port: 6379,
        },
        new BinaryEncoder() // pass our custom encoder
      ),
    },
  },
})
```

**Breaking Change**: The encoder signature has changed. The `decode` function now accepts a `string` or a `Buffer`. I think we can release that this in a minor release, since i think nobody has created a custom encoder yet. 