### PR TITLE
feat(redis): add node redis transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ioredis": "^5.9.0",
     "mqtt": "^5.14.1",
     "prettier": "^3.7.4",
+    "redis": "^5.10.0",
     "release-it": "^19.2.3",
     "testcontainers": "^11.11.0",
     "ts-node-maintained": "^10.9.6",
@@ -58,10 +59,14 @@
     "object-hash": "^3.0.0"
   },
   "peerDependencies": {
-    "ioredis": "^5.0.0"
+    "ioredis": "^5.0.0",
+    "redis": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "ioredis": {
+      "optional": true
+    },
+    "redis": {
       "optional": true
     }
   },

--- a/src/transports/node_redis.ts
+++ b/src/transports/node_redis.ts
@@ -1,0 +1,194 @@
+/**
+ * @boringnode/bus
+ *
+ * @license MIT
+ * @copyright BoringNode
+ */
+
+import { createClient, createCluster } from 'redis'
+import { assert } from '@poppinss/utils/assert'
+
+import debug from '../debug.js'
+import { JsonEncoder } from '../encoders/json_encoder.js'
+import type {
+  Transport,
+  TransportEncoder,
+  TransportMessage,
+  Serializable,
+  SubscribeHandler,
+  NodeRedisTransportConfig,
+  NodeRedisTransportConnection,
+  NodeRedisTransportOptions,
+  NodeRedisClusterTransportConfig,
+} from '../types/main.js'
+
+export function nodeRedis(config: NodeRedisTransportConfig | string, encoder?: TransportEncoder) {
+  return () => new NodeRedisTransport(config, encoder)
+}
+
+function isNodeRedisConnection(value: unknown): value is NodeRedisTransportConnection {
+  const candidate = value as NodeRedisTransportConnection
+
+  return (
+    typeof candidate?.duplicate === 'function' &&
+    typeof candidate?.publish === 'function' &&
+    typeof candidate?.subscribe === 'function'
+  )
+}
+
+function isClusterConfig(
+  value: NodeRedisTransportConfig
+): value is NodeRedisClusterTransportConfig {
+  const candidate = value as NodeRedisClusterTransportConfig
+  return typeof candidate?.rootNodes !== 'undefined'
+}
+
+export class NodeRedisTransport implements Transport {
+  readonly #publisher: NodeRedisTransportConnection
+  readonly #subscriber: NodeRedisTransportConnection
+  readonly #encoder: TransportEncoder
+  readonly #useMessageBuffer: boolean = false
+
+  #id: string | undefined
+  #connected: boolean = false
+  #connecting: Promise<void> | null = null
+
+  constructor(options: NodeRedisTransportConfig | string, encoder?: TransportEncoder)
+  constructor(
+    connection: NodeRedisTransportConnection,
+    encoder?: TransportEncoder,
+    options?: NodeRedisTransportOptions
+  )
+  constructor(
+    options: NodeRedisTransportConfig | string | NodeRedisTransportConnection,
+    encoder?: TransportEncoder,
+    transportOptions?: NodeRedisTransportOptions
+  ) {
+    this.#encoder = encoder ?? new JsonEncoder()
+
+    if (isNodeRedisConnection(options)) {
+      this.#publisher = options.duplicate()
+      this.#subscriber = options.duplicate()
+      this.#useMessageBuffer = transportOptions?.useMessageBuffer ?? false
+      this.#bindErrorHandlers()
+      return
+    }
+
+    if (typeof options === 'string') {
+      this.#publisher = createClient({ url: options })
+      this.#subscriber = createClient({ url: options })
+      this.#bindErrorHandlers()
+      return
+    }
+
+    this.#useMessageBuffer = options.useMessageBuffer ?? false
+
+    if (isClusterConfig(options)) {
+      const { useMessageBuffer, ...clusterOptions } = options
+      this.#publisher = createCluster(clusterOptions) as unknown as NodeRedisTransportConnection
+      this.#subscriber = createCluster(clusterOptions) as unknown as NodeRedisTransportConnection
+      this.#bindErrorHandlers()
+      return
+    }
+
+    const { useMessageBuffer, ...clientOptions } = options
+    this.#publisher = createClient(clientOptions) as unknown as NodeRedisTransportConnection
+    this.#subscriber = createClient(clientOptions) as unknown as NodeRedisTransportConnection
+    this.#bindErrorHandlers()
+  }
+
+  setId(id: string): Transport {
+    this.#id = id
+
+    return this
+  }
+
+  async disconnect(): Promise<void> {
+    await Promise.all([
+      this.#publisher.isOpen ? this.#publisher.close() : Promise.resolve(),
+      this.#subscriber.isOpen ? this.#subscriber.close() : Promise.resolve(),
+    ])
+
+    this.#connected = false
+    this.#connecting = null
+  }
+
+  async publish(channel: string, message: Serializable): Promise<void> {
+    assert(this.#id, 'You must set an id before publishing a message')
+    await this.#ensureConnected()
+
+    const encoded = this.#encoder.encode({ payload: message, busId: this.#id })
+
+    await this.#publisher.publish(channel, encoded)
+  }
+
+  async subscribe<T extends Serializable>(
+    channel: string,
+    handler: SubscribeHandler<T>
+  ): Promise<void> {
+    await this.#ensureConnected()
+
+    await this.#subscriber.subscribe(
+      channel,
+      (message: string | Buffer) => {
+        debug('received message for channel "%s"', channel)
+
+        const data = this.#encoder.decode<TransportMessage<T>>(message)
+
+        /**
+         * Ignore messages published by this bus instance
+         */
+        if (data.busId === this.#id) {
+          debug('ignoring message published by the same bus instance')
+          return
+        }
+
+        // @ts-expect-error - TODO: Weird typing issue
+        handler(data.payload)
+      },
+      this.#useMessageBuffer
+    )
+  }
+
+  onReconnect(callback: () => void): void {
+    this.#subscriber.on('reconnecting', callback)
+  }
+
+  async unsubscribe(channel: string): Promise<void> {
+    await this.#ensureConnected()
+    await this.#subscriber.unsubscribe(channel)
+  }
+
+  async #ensureConnected() {
+    if (this.#connected) {
+      return
+    }
+
+    if (this.#connecting) {
+      await this.#connecting
+      return
+    }
+
+    this.#connecting = Promise.all([
+      this.#publisher.isOpen ? Promise.resolve() : this.#publisher.connect(),
+      this.#subscriber.isOpen ? Promise.resolve() : this.#subscriber.connect(),
+    ]).then(() => undefined)
+
+    try {
+      await this.#connecting
+      this.#connected = true
+    } finally {
+      this.#connecting = null
+    }
+  }
+
+  #bindErrorHandlers() {
+    this.#publisher.on('error', (error) => {
+      debug('node-redis publisher error: %O', error)
+    })
+
+    this.#subscriber.on('error', (error) => {
+      debug('node-redis subscriber error: %O', error)
+    })
+  }
+}

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -7,8 +7,15 @@
 
 import type { RedisOptions } from 'ioredis'
 import type { IClientOptions } from 'mqtt'
+import type {
+  RedisClientOptions,
+  RedisClusterOptions,
+  createClient,
+  createCluster
+} from 'redis'
 
 export type { Redis, Cluster } from 'ioredis'
+export type { RedisClientType, RedisClusterType } from 'redis'
 export type TransportFactory = () => Transport
 
 /**
@@ -44,6 +51,33 @@ export interface RedisTransportOptions {
    * If true, we will use `messageBuffer` event instead of `message` event
    * that is emitted by ioredis. `messageBuffer` will returns a buffer instead
    * of a string and this is useful when you are dealing with binary data.
+   */
+  useMessageBuffer?: boolean
+}
+
+export interface NodeRedisClientTransportConfig extends RedisClientOptions {
+  /**
+   * If true, we will subscribe in buffer mode.
+   */
+  useMessageBuffer?: boolean
+}
+
+export interface NodeRedisClusterTransportConfig extends RedisClusterOptions {
+  /**
+   * If true, we will subscribe in buffer mode.
+   */
+  useMessageBuffer?: boolean
+}
+
+export type NodeRedisTransportConnection = ReturnType<typeof createClient> | ReturnType<typeof createCluster>
+
+export type NodeRedisTransportConfig =
+  | NodeRedisClientTransportConfig
+  | NodeRedisClusterTransportConfig
+
+export interface NodeRedisTransportOptions {
+  /**
+   * If true, we will subscribe in buffer mode.
    */
   useMessageBuffer?: boolean
 }

--- a/tests/drivers/node_redis_transport.spec.ts
+++ b/tests/drivers/node_redis_transport.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * @boringnode/bus
+ *
+ * @license MIT
+ * @copyright BoringNode
+ */
+
+import { setTimeout } from 'node:timers/promises'
+import { test } from '@japa/runner'
+import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis'
+import { createClient, createCluster } from 'redis'
+import { NodeRedisTransport } from '../../src/transports/node_redis.js'
+import { JsonEncoder } from '../../src/encoders/json_encoder.js'
+import { TransportEncoder, TransportMessage } from '../../src/types/main.js'
+
+test.group('Node Redis Transport', (group) => {
+  let container: StartedRedisContainer
+
+  group.setup(async () => {
+    container = await new RedisContainer('redis:7.2').start()
+
+    return async () => {
+      await container.stop()
+    }
+  })
+
+  test('transport should not receive message emitted by itself', async ({ assert, cleanup }) => {
+    const transport = new NodeRedisTransport(container.getConnectionUrl()).setId('bus')
+    cleanup(() => transport.disconnect())
+
+    await transport.subscribe('testing-channel', () => {
+      assert.fail('Bus should not receive message emitted by itself')
+    })
+
+    await transport.publish('testing-channel', 'test')
+    await setTimeout(1000)
+  }).disableTimeout()
+
+  test('transport should receive message emitted by another bus', async ({
+    assert,
+    cleanup,
+  }, done) => {
+    assert.plan(1)
+
+    const transport1 = new NodeRedisTransport(container.getConnectionUrl()).setId('bus1')
+    const transport2 = new NodeRedisTransport(container.getConnectionUrl()).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.equal(payload, 'test')
+      done()
+    })
+
+    await setTimeout(200)
+
+    await transport2.publish('testing-channel', 'test')
+  }).waitForDone()
+
+  test('transport should trigger onReconnect when the client reconnects', async ({
+    assert,
+    cleanup,
+  }) => {
+    const transport = new NodeRedisTransport(container.getConnectionUrl()).setId('bus')
+    cleanup(() => transport.disconnect())
+
+    let onReconnectTriggered = false
+    transport.onReconnect(() => {
+      onReconnectTriggered = true
+    })
+
+    await transport.subscribe('testing-channel', () => {})
+
+    await container.restart()
+    await setTimeout(200)
+
+    assert.isTrue(onReconnectTriggered)
+  })
+
+  test('message should be encoded and decoded correctly when using JSON encoder', async ({
+    assert,
+    cleanup,
+  }, done) => {
+    assert.plan(1)
+
+    const transport1 = new NodeRedisTransport(container.getConnectionUrl(), new JsonEncoder()).setId(
+      'bus1'
+    )
+    const transport2 = new NodeRedisTransport(container.getConnectionUrl(), new JsonEncoder()).setId(
+      'bus2'
+    )
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    const data = { test: 'test' }
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.deepEqual(payload, data)
+      done()
+    })
+
+    await setTimeout(200)
+
+    await transport2.publish('testing-channel', data)
+  }).waitForDone()
+
+  test('send binary data using useMessageBuffer', async ({ assert, cleanup }, done) => {
+    assert.plan(1)
+
+    class BinaryEncoder implements TransportEncoder {
+      encode(message: TransportMessage<any>) {
+        return Buffer.from(JSON.stringify(message))
+      }
+
+      decode(data: string | Buffer) {
+        const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'binary')
+        return JSON.parse(buffer.toString())
+      }
+    }
+
+    const transport1 = new NodeRedisTransport(
+      { url: container.getConnectionUrl(), useMessageBuffer: true },
+      new BinaryEncoder()
+    ).setId('bus1')
+
+    const transport2 = new NodeRedisTransport(
+      { url: container.getConnectionUrl(), useMessageBuffer: true },
+      new BinaryEncoder()
+    ).setId('bus2')
+
+    cleanup(() => {
+      transport1.disconnect()
+      transport2.disconnect()
+    })
+
+    const data = ['foo', '👍']
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.deepEqual(payload, data)
+      done()
+    })
+
+    await setTimeout(200)
+    await transport2.publish('testing-channel', data)
+  }).waitForDone()
+
+  test('should work with an existing redis instance', async ({ assert, cleanup }, done) => {
+    assert.plan(1)
+
+    const redisInstance = createClient({
+      socket: {
+        host: container.getHost(),
+        port: container.getMappedPort(6379),
+      },
+    })
+    redisInstance.on('error', () => {})
+    await redisInstance.connect()
+
+    cleanup(async () => {
+      if (redisInstance.isOpen) {
+        await redisInstance.close()
+      }
+    })
+
+    const transport1 = new NodeRedisTransport(redisInstance).setId('bus1')
+    const transport2 = new NodeRedisTransport(redisInstance).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.equal(payload, 'test')
+      done()
+    })
+
+    await setTimeout(200)
+
+    await transport2.publish('testing-channel', 'test')
+  }).waitForDone()
+
+  test('should work with an existing cluster instance', async ({ assert, cleanup }, done) => {
+    assert.plan(1)
+
+    const cluster = createCluster({
+      rootNodes: [{ url: 'redis://127.0.0.1:7000' }],
+    })
+    cluster.on('error', () => {})
+    await cluster.connect()
+
+    cleanup(async () => {
+      if (cluster.isOpen) {
+        await cluster.close()
+      }
+    })
+
+    const transport1 = new NodeRedisTransport(cluster).setId('bus1')
+    const transport2 = new NodeRedisTransport(cluster).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.equal(payload, 'test')
+      done()
+    })
+
+    await setTimeout(200)
+
+    await transport2.publish('testing-channel', 'test')
+  })
+    .waitForDone()
+    .skip(!!process.env.CI, 'Skipping cluster test on CI')
+
+  test('send binary data using useMessageBuffer with existing redis instance', async ({
+    assert,
+    cleanup,
+  }, done) => {
+    assert.plan(1)
+
+    class BinaryEncoder implements TransportEncoder {
+      encode(message: TransportMessage<any>) {
+        return Buffer.from(JSON.stringify(message))
+      }
+
+      decode(data: string | Buffer) {
+        const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'binary')
+        return JSON.parse(buffer.toString())
+      }
+    }
+
+    const redisInstance = createClient({ url: container.getConnectionUrl() })
+    redisInstance.on('error', () => {})
+    await redisInstance.connect()
+
+    cleanup(async () => {
+      if (redisInstance.isOpen) {
+        await redisInstance.close()
+      }
+    })
+
+    const transport1 = new NodeRedisTransport(redisInstance, new BinaryEncoder(), {
+      useMessageBuffer: true,
+    }).setId('bus1')
+
+    const transport2 = new NodeRedisTransport(redisInstance, new BinaryEncoder(), {
+      useMessageBuffer: true,
+    }).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    const data = ['foo', '👍']
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.deepEqual(payload, data)
+      done()
+    })
+
+    await setTimeout(200)
+    await transport2.publish('testing-channel', data)
+  }).waitForDone()
+})


### PR DESCRIPTION
Add support for official Redis package. Should implement request from https://github.com/boringnode/bus/issues/41

Couple of notes

* Couldn’t run tests for cluster either for ioredis or this implementation. When I create containers for Redis cluster I always get message that there are no nodes available
* Typechecking is very slow when trying to use types for cluster mode. For client mode there isn’t any noticable performance difference. There is open issue for this on official repository: https://github.com/redis/node-redis/issues/2975


Also, project has issues when using default Yarn configuration:

```
➤ YN0066: │ typescript@patch:typescript@npm%3A5.9.3#builtin<compat/typescript>::version=5.9.3&hash=8133ad: Cannot apply hunk #1 (set enableInlineHunks for details)
```

I went and use default npm configuration as fallback.
