### PR TITLE
fix(redis): detect an existing connection by shape instead of instanceof, and support ioredis 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "del-cli": "^7.0.0",
     "eslint": "^10.6.0",
     "ioredis": "^5.11.1",
+    "ioredis-v6": "npm:ioredis@^6.0.0",
     "mqtt": "^5.15.2",
     "prettier": "^3.9.4",
     "release-it": "^20.2.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "object-hash": "^3.0.0"
   },
   "peerDependencies": {
-    "ioredis": "^5.0.0"
+    "ioredis": "^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "ioredis": {

--- a/src/transports/redis.ts
+++ b/src/transports/redis.ts
@@ -5,8 +5,10 @@
  * @copyright BoringNode
  */
 
-import { Redis, Cluster } from 'ioredis'
+import { Redis } from 'ioredis'
+import type { Cluster } from 'ioredis'
 import { assert } from '@poppinss/utils/assert'
+import { InvalidArgumentsException } from '@poppinss/utils/exception'
 
 import debug from '../debug.js'
 import { JsonEncoder } from '../encoders/json_encoder.js'
@@ -22,6 +24,58 @@ import type {
 
 export function redis(config: RedisTransportConfig, encoder?: TransportEncoder) {
   return () => new RedisTransport(config, encoder)
+}
+
+/**
+ * Detect an existing `ioredis` client by its shape rather than with `instanceof`.
+ *
+ * `instanceof` is evaluated against the copy of `ioredis` this package resolved.
+ * When the host application resolves a different copy - a different major, or
+ * simply a duplicated one in the dependency tree - the check returns `false` for
+ * a perfectly valid client and we would fall through to `new Redis(client)`,
+ * which silently connects to `127.0.0.1:6379`.
+ *
+ * `duplicate` and `sendCommand` are on the prototype of both `Redis` and
+ * `Cluster` in every major, and neither name exists in `RedisOptions` or
+ * `ClusterOptions`, so an options object can never be mistaken for a client.
+ */
+function isRedisClient(value: unknown): value is Redis | Cluster {
+  if (typeof value !== 'object' || value === null) return false
+
+  const candidate = value as Partial<Redis>
+
+  return typeof candidate.duplicate === 'function' && typeof candidate.sendCommand === 'function'
+}
+
+/**
+ * `Redis#duplicate` and `Cluster#duplicate` are both parameterless-callable at
+ * runtime, but TypeScript cannot resolve the call against a `Redis | Cluster`
+ * union: from ioredis 6 on, both signatures are generic over the reply mapping
+ * and none of them is compatible with the other. Going through a narrow local
+ * signature keeps the source compiling against ioredis 5 and 6 alike.
+ */
+function duplicateClient(client: Redis | Cluster): Redis | Cluster {
+  return (client.duplicate as unknown as () => Redis | Cluster)()
+}
+
+/**
+ * Values that look like a client - they carry a `status`, an `options` bag and
+ * an `emit` method - but that we could not recognize as one. None of those
+ * names are valid `ioredis` options, so a legitimate configuration object never
+ * lands here. Rather than quietly building a connection to `127.0.0.1:6379`
+ * out of it, we fail loudly.
+ */
+function looksLikeUnsupportedRedisClient(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false
+
+  const candidate = value as Record<string, unknown>
+
+  return (
+    typeof candidate.status === 'string' &&
+    typeof candidate.options === 'object' &&
+    candidate.options !== null &&
+    typeof candidate.emit === 'function'
+  )
 }
 
 export class RedisTransport implements Transport {
@@ -51,11 +105,18 @@ export class RedisTransport implements Transport {
      * If an existing Redis or Cluster instance is passed, we duplicate it
      * to have separate connections for publisher and subscriber
      */
-    if (options instanceof Redis || options instanceof Cluster) {
-      this.#publisher = options.duplicate()
-      this.#subscriber = options.duplicate()
+    if (isRedisClient(options)) {
+      this.#publisher = duplicateClient(options)
+      this.#subscriber = duplicateClient(options)
       this.#useMessageBuffer = transportOptions?.useMessageBuffer ?? false
     } else {
+      if (looksLikeUnsupportedRedisClient(options)) {
+        throw new InvalidArgumentsException(
+          'Cannot use the given Redis connection with "RedisTransport". Expected an "ioredis" ' +
+            'client exposing "duplicate()" and "sendCommand()", or a connection options object.'
+        )
+      }
+
       // @ts-expect-error - merged definitions of overloaded constructor is not public
       this.#publisher = new Redis(options)
       // @ts-expect-error - merged definitions of overloaded constructor is not public

--- a/tests/drivers/redis_transport.spec.ts
+++ b/tests/drivers/redis_transport.spec.ts
@@ -13,6 +13,43 @@ import { RedisTransport } from '../../src/transports/redis.js'
 import { JsonEncoder } from '../../src/encoders/json_encoder.js'
 import { type TransportEncoder, type TransportMessage } from '../../src/types/main.js'
 
+/**
+ * A stand-in for a client coming from *another* copy of `ioredis` - a different
+ * major installed alongside ours, which is the normal outcome of a package
+ * manager resolving two ranges.
+ *
+ * The Proxy sits on a null-prototype target and forwards everything to a real
+ * client, so it has exactly the shape of a client while failing
+ * `instanceof Redis` / `instanceof Cluster` against the copy this package
+ * resolved - which is precisely what a foreign-major client looks like from in
+ * here. Only one `ioredis` can be installed in this repository, so this is the
+ * faithful way to express the situation in a test.
+ */
+function asForeignMajorClient<T extends Redis | Cluster>(client: T) {
+  const duplicates: T[] = []
+
+  const proxy = new Proxy(Object.create(null), {
+    get(_target, property) {
+      const value = (client as any)[property]
+
+      if (property === 'duplicate') {
+        return (...args: any[]) => {
+          const duplicated = value.apply(client, args)
+          duplicates.push(duplicated)
+          return duplicated
+        }
+      }
+
+      return typeof value === 'function' ? value.bind(client) : value
+    },
+    has(_target, property) {
+      return property in (client as any)
+    },
+  }) as T
+
+  return { client: proxy, duplicates }
+}
+
 test.group('Redis Transport', (group) => {
   let container: StartedRedisContainer
 
@@ -359,5 +396,191 @@ test.group('Redis Transport', (group) => {
 
     await setTimeout(200)
     await transport2.publish('testing-channel', data)
+  }).waitForDone()
+
+  test('should reuse a client coming from another copy of ioredis', async ({ assert, cleanup }) => {
+    const redisInstance = new Redis({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    })
+    const foreign = asForeignMajorClient(redisInstance)
+
+    cleanup(async () => {
+      await redisInstance.quit()
+    })
+
+    /**
+     * The premise of the test: same shape, but not an instance of the `ioredis`
+     * classes this package resolved.
+     */
+    assert.isFalse(foreign.client instanceof Redis)
+    assert.isFalse(foreign.client instanceof Cluster)
+
+    const transport = new RedisTransport(foreign.client).setId('bus1')
+    cleanup(() => transport.disconnect())
+
+    /**
+     * The connection must have been duplicated (publisher + subscriber) rather
+     * than handed to `new Redis()` as if it were an options object, which would
+     * silently dial 127.0.0.1:6379.
+     */
+    assert.lengthOf(foreign.duplicates, 2)
+
+    /**
+     * And the messages must really land on the configured server, not on the
+     * default one.
+     */
+    const witness = new Redis({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    })
+    cleanup(async () => {
+      await witness.quit()
+    })
+
+    const received = new Promise<string>((resolve) => {
+      witness.on('message', (_channel, message) => resolve(message))
+    })
+    await witness.subscribe('foreign-client-channel')
+
+    await transport.publish('foreign-client-channel', 'test')
+
+    const message = await Promise.race([received, setTimeout(2000).then(() => 'timed-out')])
+
+    assert.deepEqual(JSON.parse(message), { payload: 'test', busId: 'bus1' })
+  })
+
+  test('should reuse a cluster client coming from another copy of ioredis', async ({
+    assert,
+    cleanup,
+  }) => {
+    const cluster = new Cluster([{ host: '127.0.0.1', port: 7000 }], { lazyConnect: true })
+    const foreign = asForeignMajorClient(cluster)
+
+    cleanup(async () => {
+      cluster.disconnect()
+    })
+
+    assert.isFalse(foreign.client instanceof Redis)
+    assert.isFalse(foreign.client instanceof Cluster)
+
+    const transport = new RedisTransport(foreign.client)
+    cleanup(() => {
+      for (const duplicated of foreign.duplicates) duplicated.disconnect()
+    })
+
+    assert.lengthOf(foreign.duplicates, 2)
+    assert.instanceOf(foreign.duplicates[0], Cluster)
+
+    transport.onReconnect(() => {})
+    assert.equal(foreign.duplicates[1].listenerCount('reconnecting'), 1)
+  })
+
+  test('should keep useMessageBuffer when given a client from another copy of ioredis', async ({
+    assert,
+    cleanup,
+  }, done) => {
+    assert.plan(4)
+
+    class BinaryEncoder implements TransportEncoder {
+      encode(message: TransportMessage<any>) {
+        return Buffer.from(JSON.stringify(message))
+      }
+
+      decode(data: string | Buffer) {
+        const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'binary')
+        return JSON.parse(buffer.toString())
+      }
+    }
+
+    const redisInstance = new Redis({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    })
+
+    cleanup(async () => {
+      await redisInstance.quit()
+    })
+
+    const foreign1 = asForeignMajorClient(redisInstance)
+    const foreign2 = asForeignMajorClient(redisInstance)
+
+    const transport1 = new RedisTransport(foreign1.client, new BinaryEncoder(), {
+      useMessageBuffer: true,
+    }).setId('bus1')
+
+    const transport2 = new RedisTransport(foreign2.client, new BinaryEncoder(), {
+      useMessageBuffer: true,
+    }).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    /**
+     * `useMessageBuffer` only reaches the transport through the third argument,
+     * which is ignored on the options-object branch. If the client is not
+     * recognized, it silently degrades to `false` and the subscriber listens on
+     * "message" instead of "messageBuffer" - decoding binary payloads through a
+     * lossy string.
+     */
+    assert.lengthOf(foreign1.duplicates, 2)
+    assert.equal(foreign1.duplicates[1].listenerCount('messageBuffer'), 1)
+    assert.equal(foreign1.duplicates[1].listenerCount('message'), 0)
+
+    const data = ['foo', '👍']
+
+    await transport1.subscribe('testing-channel', (payload) => {
+      assert.deepEqual(payload, data)
+      done()
+    })
+
+    await setTimeout(200)
+    await transport2.publish('testing-channel', data)
+  }).waitForDone()
+
+  test('should throw instead of dialing localhost for an unusable client', async ({ assert }) => {
+    const unusable = {
+      status: 'ready',
+      options: { host: 'redis.internal', port: 6380 },
+      emit: () => true,
+    }
+
+    assert.throws(
+      // @ts-expect-error - deliberately not a valid argument
+      () => new RedisTransport(unusable),
+      /Cannot use the given Redis connection with "RedisTransport"/
+    )
+  })
+
+  test('should still build a new connection from a plain options object', async ({
+    assert,
+    cleanup,
+  }, done) => {
+    assert.plan(1)
+
+    const transport1 = new RedisTransport({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    }).setId('bus1')
+
+    const transport2 = new RedisTransport({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    }).setId('bus2')
+
+    cleanup(async () => {
+      await transport1.disconnect()
+      await transport2.disconnect()
+    })
+
+    await transport1.subscribe('options-object-channel', (payload) => {
+      assert.equal(payload, 'test')
+      done()
+    })
+
+    await setTimeout(200)
+    await transport2.publish('options-object-channel', 'test')
   }).waitForDone()
 })

--- a/tests/drivers/redis_transport.spec.ts
+++ b/tests/drivers/redis_transport.spec.ts
@@ -8,46 +8,50 @@
 import { setImmediate, setTimeout } from 'node:timers/promises'
 import { test } from '@japa/runner'
 import { Redis, Cluster } from 'ioredis'
+import { Redis as ForeignRedis, Cluster as ForeignCluster } from 'ioredis-v6'
 import { RedisContainer, type StartedRedisContainer } from '@testcontainers/redis'
 import { RedisTransport } from '../../src/transports/redis.js'
 import { JsonEncoder } from '../../src/encoders/json_encoder.js'
 import { type TransportEncoder, type TransportMessage } from '../../src/types/main.js'
 
 /**
- * A stand-in for a client coming from *another* copy of `ioredis` - a different
- * major installed alongside ours, which is the normal outcome of a package
- * manager resolving two ranges.
+ * `ioredis-v6` is a second, real copy of `ioredis` installed side by side with
+ * the one this package resolves, through the npm alias
+ * `"ioredis-v6": "npm:ioredis@^6.0.0"`. A client built from it is exactly what
+ * an application running `@adonisjs/redis@11` hands to a bus resolved against
+ * `ioredis` 5: same API, different classes, so `instanceof` says `false`.
  *
- * The Proxy sits on a null-prototype target and forwards everything to a real
- * client, so it has exactly the shape of a client while failing
- * `instanceof Redis` / `instanceof Cluster` against the copy this package
- * resolved - which is precisely what a foreign-major client looks like from in
- * here. Only one `ioredis` can be installed in this repository, so this is the
- * faithful way to express the situation in a test.
+ * The cast is part of the scenario too - the two copies ship two unrelated sets
+ * of types - but only the runtime behaviour is under test here.
  */
-function asForeignMajorClient<T extends Redis | Cluster>(client: T) {
+function asForeignClient(client: ForeignRedis): Redis
+function asForeignClient(client: ForeignCluster): Cluster
+function asForeignClient(client: ForeignRedis | ForeignCluster) {
+  return client as unknown as Redis | Cluster
+}
+
+/**
+ * Records what `duplicate()` returns, so a test can tell "the transport reused
+ * the connection" from "the transport built a brand new one".
+ *
+ * The spy is an own property shadowing the prototype method, so the client
+ * remains an instance of its own `ioredis` copy - which is the very thing these
+ * tests are about.
+ */
+function spyOnDuplicate<T extends ForeignRedis | ForeignCluster>(client: T): T[] {
   const duplicates: T[] = []
+  const duplicate = (client.duplicate as unknown as () => T).bind(client)
 
-  const proxy = new Proxy(Object.create(null), {
-    get(_target, property) {
-      const value = (client as any)[property]
-
-      if (property === 'duplicate') {
-        return (...args: any[]) => {
-          const duplicated = value.apply(client, args)
-          duplicates.push(duplicated)
-          return duplicated
-        }
-      }
-
-      return typeof value === 'function' ? value.bind(client) : value
+  Object.defineProperty(client, 'duplicate', {
+    configurable: true,
+    value: () => {
+      const duplicated = duplicate()
+      duplicates.push(duplicated)
+      return duplicated
     },
-    has(_target, property) {
-      return property in (client as any)
-    },
-  }) as T
+  })
 
-  return { client: proxy, duplicates }
+  return duplicates
 }
 
 test.group('Redis Transport', (group) => {
@@ -399,24 +403,27 @@ test.group('Redis Transport', (group) => {
   }).waitForDone()
 
   test('should reuse a client coming from another copy of ioredis', async ({ assert, cleanup }) => {
-    const redisInstance = new Redis({
+    const foreignClient = new ForeignRedis({
       host: container.getHost(),
       port: container.getMappedPort(6379),
     })
-    const foreign = asForeignMajorClient(redisInstance)
 
     cleanup(async () => {
-      await redisInstance.quit()
+      await foreignClient.quit()
     })
 
     /**
-     * The premise of the test: same shape, but not an instance of the `ioredis`
+     * The premise of the test: a genuine `ioredis` client, built from a genuine
+     * second copy of the package, which is therefore not an instance of the
      * classes this package resolved.
      */
-    assert.isFalse(foreign.client instanceof Redis)
-    assert.isFalse(foreign.client instanceof Cluster)
+    assert.isFalse((ForeignRedis as unknown) === (Redis as unknown))
+    assert.instanceOf(foreignClient, ForeignRedis)
+    assert.isFalse(foreignClient instanceof Redis)
+    assert.isFalse(foreignClient instanceof Cluster)
 
-    const transport = new RedisTransport(foreign.client).setId('bus1')
+    const duplicates = spyOnDuplicate(foreignClient)
+    const transport = new RedisTransport(asForeignClient(foreignClient)).setId('bus1')
     cleanup(() => transport.disconnect())
 
     /**
@@ -424,11 +431,13 @@ test.group('Redis Transport', (group) => {
      * than handed to `new Redis()` as if it were an options object, which would
      * silently dial 127.0.0.1:6379.
      */
-    assert.lengthOf(foreign.duplicates, 2)
+    assert.lengthOf(duplicates, 2)
+    assert.instanceOf(duplicates[0], ForeignRedis)
 
     /**
      * And the messages must really land on the configured server, not on the
-     * default one.
+     * default one. The witness connects to the container explicitly, so it only
+     * ever sees what was published there.
      */
     const witness = new Redis({
       host: container.getHost(),
@@ -454,34 +463,37 @@ test.group('Redis Transport', (group) => {
     assert,
     cleanup,
   }) => {
-    const cluster = new Cluster([{ host: '127.0.0.1', port: 7000 }], { lazyConnect: true })
-    const foreign = asForeignMajorClient(cluster)
-
-    cleanup(async () => {
-      cluster.disconnect()
+    const foreignCluster = new ForeignCluster([{ host: '127.0.0.1', port: 7000 }], {
+      lazyConnect: true,
     })
 
-    assert.isFalse(foreign.client instanceof Redis)
-    assert.isFalse(foreign.client instanceof Cluster)
-
-    const transport = new RedisTransport(foreign.client)
     cleanup(() => {
-      for (const duplicated of foreign.duplicates) duplicated.disconnect()
+      foreignCluster.disconnect()
     })
 
-    assert.lengthOf(foreign.duplicates, 2)
-    assert.instanceOf(foreign.duplicates[0], Cluster)
+    assert.isFalse((ForeignCluster as unknown) === (Cluster as unknown))
+    assert.instanceOf(foreignCluster, ForeignCluster)
+    assert.isFalse(foreignCluster instanceof Redis)
+    assert.isFalse(foreignCluster instanceof Cluster)
+
+    const duplicates = spyOnDuplicate(foreignCluster)
+    const transport = new RedisTransport(asForeignClient(foreignCluster))
+    cleanup(() => {
+      for (const duplicated of duplicates) duplicated.disconnect()
+    })
+
+    assert.lengthOf(duplicates, 2)
+    assert.instanceOf(duplicates[0], ForeignCluster)
+    assert.isFalse(duplicates[0] instanceof Cluster)
 
     transport.onReconnect(() => {})
-    assert.equal(foreign.duplicates[1].listenerCount('reconnecting'), 1)
+    assert.equal(duplicates[1].listenerCount('reconnecting'), 1)
   })
 
   test('should keep useMessageBuffer when given a client from another copy of ioredis', async ({
     assert,
     cleanup,
-  }, done) => {
-    assert.plan(4)
-
+  }) => {
     class BinaryEncoder implements TransportEncoder {
       encode(message: TransportMessage<any>) {
         return Buffer.from(JSON.stringify(message))
@@ -493,23 +505,31 @@ test.group('Redis Transport', (group) => {
       }
     }
 
-    const redisInstance = new Redis({
+    const subscriberClient = new ForeignRedis({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+    })
+
+    const publisherClient = new ForeignRedis({
       host: container.getHost(),
       port: container.getMappedPort(6379),
     })
 
     cleanup(async () => {
-      await redisInstance.quit()
+      await subscriberClient.quit()
+      await publisherClient.quit()
     })
 
-    const foreign1 = asForeignMajorClient(redisInstance)
-    const foreign2 = asForeignMajorClient(redisInstance)
+    assert.instanceOf(subscriberClient, ForeignRedis)
+    assert.isFalse(subscriberClient instanceof Redis)
 
-    const transport1 = new RedisTransport(foreign1.client, new BinaryEncoder(), {
+    const duplicates = spyOnDuplicate(subscriberClient)
+
+    const transport1 = new RedisTransport(asForeignClient(subscriberClient), new BinaryEncoder(), {
       useMessageBuffer: true,
     }).setId('bus1')
 
-    const transport2 = new RedisTransport(foreign2.client, new BinaryEncoder(), {
+    const transport2 = new RedisTransport(asForeignClient(publisherClient), new BinaryEncoder(), {
       useMessageBuffer: true,
     }).setId('bus2')
 
@@ -525,20 +545,36 @@ test.group('Redis Transport', (group) => {
      * "message" instead of "messageBuffer" - decoding binary payloads through a
      * lossy string.
      */
-    assert.lengthOf(foreign1.duplicates, 2)
-    assert.equal(foreign1.duplicates[1].listenerCount('messageBuffer'), 1)
-    assert.equal(foreign1.duplicates[1].listenerCount('message'), 0)
+    assert.lengthOf(duplicates, 2)
+    assert.equal(duplicates[1].listenerCount('messageBuffer'), 1)
+    assert.equal(duplicates[1].listenerCount('message'), 0)
 
     const data = ['foo', '👍']
 
-    await transport1.subscribe('testing-channel', (payload) => {
-      assert.deepEqual(payload, data)
-      done()
+    /**
+     * The exact bytes the publisher writes. Listening alongside the transport on
+     * its own subscriber lets us assert the payload survived the trip untouched,
+     * rather than through a UTF-8 round trip that happens to be lossless.
+     */
+    const expectedBytes = new BinaryEncoder().encode({ payload: data, busId: 'bus2' })
+    let receivedBytes: Buffer | undefined
+    duplicates[1].on('messageBuffer', (_channel: Buffer, message: Buffer) => {
+      receivedBytes = message
     })
+
+    let resolvePayload!: (payload: unknown) => void
+    const payloadReceived = new Promise<unknown>((resolve) => (resolvePayload = resolve))
+    await transport1.subscribe('testing-channel', resolvePayload)
 
     await setTimeout(200)
     await transport2.publish('testing-channel', data)
-  }).waitForDone()
+
+    const payload = await Promise.race([payloadReceived, setTimeout(2000).then(() => 'timed-out')])
+
+    assert.deepEqual(payload, data)
+    assert.isTrue(Buffer.isBuffer(receivedBytes))
+    assert.isTrue(receivedBytes!.equals(expectedBytes as Buffer))
+  })
 
   test('should throw instead of dialing localhost for an unusable client', async ({ assert }) => {
     const unusable = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,7 @@ __metadata:
     del-cli: "npm:^7.0.0"
     eslint: "npm:^10.6.0"
     ioredis: "npm:^5.11.1"
+    ioredis-v6: "npm:ioredis@^6.0.0"
     mqtt: "npm:^5.15.2"
     object-hash: "npm:^3.0.0"
     prettier: "npm:^3.9.4"
@@ -701,6 +702,13 @@ __metadata:
   version: 1.10.0
   resolution: "@ioredis/commands@npm:1.10.0"
   checksum: 10c0/baf91e62d0e64ef2b5f7ca4413dc2456fe250e87483beac4a1c8ef1fe5ad0d2fcdeb9b89d4556d8ef6c7455c64a964359d729601fdb06b2f4c76c35dd59afa99
+  languageName: node
+  linkType: hard
+
+"@ioredis/commands@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@ioredis/commands@npm:2.0.0"
+  checksum: 10c0/2fb5edb9782790c24a375cc78bd69d45ac6c268d7d7ed8e534f2d4ecc28707bde9882a04eecd68be369ae784801bf93fa267b9a76f86418b252a08f341934e35
   languageName: node
   linkType: hard
 
@@ -3919,6 +3927,20 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ioredis-v6@npm:ioredis@^6.0.0":
+  version: 6.0.0
+  resolution: "ioredis@npm:6.0.0"
+  dependencies:
+    "@ioredis/commands": "npm:2.0.0"
+    cluster-key-slot: "npm:1.1.1"
+    debug: "npm:4.4.3"
+    denque: "npm:2.1.0"
+    redis-errors: "npm:1.2.0"
+    standard-as-callback: "npm:2.1.0"
+  checksum: 10c0/6f74e1d298440c0d814e6bf9b3acdb0991d4c1862d3fa64c3828668bcc306823f7845710abdc5eab7986a35d86ec8c86c4bb9c9c7d727636d385ecb2cd40abd7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,7 +130,7 @@ __metadata:
     tsup: "npm:^8.5.1"
     typescript: "npm:^5.9.3"
   peerDependencies:
-    ioredis: ^5.0.0
+    ioredis: ^5.0.0 || ^6.0.0
   peerDependenciesMeta:
     ioredis:
       optional: true


### PR DESCRIPTION
## The bug

`RedisTransport` decides whether it was handed a live client or a plain options object with `instanceof`:

```ts
if (options instanceof Redis || options instanceof Cluster) {
  this.#publisher = options.duplicate()
  this.#subscriber = options.duplicate()
  this.#useMessageBuffer = transportOptions?.useMessageBuffer ?? false
} else {
  // @ts-expect-error - merged definitions of overloaded constructor is not public
  this.#publisher = new Redis(options)     // <- silent fallback
  // @ts-expect-error - merged definitions of overloaded constructor is not public
  this.#subscriber = new Redis(options)

  if (typeof options === 'object') {
    this.#useMessageBuffer = options.useMessageBuffer ?? false
  }
}
```

`instanceof` is evaluated against the copy of `ioredis` **this package** resolved. When the host application resolves a *different* copy — a different major, or simply a duplicate in the dependency tree — the check is `false` for a perfectly valid client, and we fall through to `new Redis(<a live client treated as an options bag>)`. A `Redis` instance has none of `host`/`port`/`path` as own properties, so ioredis keeps its defaults and connects to `127.0.0.1:6379`, silently, with no error.

**There is a second symptom, specific to this package.** `useMessageBuffer` only reaches the transport through the *third* constructor argument, which the options-object branch ignores — it reads `options.useMessageBuffer` instead, which does not exist on a client. So the subscriber quietly listens on `message` instead of `messageBuffer`, and binary payloads come back through a lossy string. That is a data-corruption bug, not just a connectivity one.

### Reproduced end to end, with two genuinely different majors installed

Built package, an app on `ioredis@6.0.0`, `@boringnode/bus` resolving its own `ioredis@5.11.1`, a Redis on port **6390** (deliberately not the default), `useMessageBuffer: true` and a binary encoder:

|                              | `main`                        | this PR       |
| ---------------------------- | ----------------------------- | ------------- |
| `duplicate()` calls          | **0**                         | 4             |
| sockets opened to `:6379`    | **5**                         | 0             |
| message reached `:6390`      | **no**                        | yes           |
| `useMessageBuffer` honoured  | **false** (raw payload was a `string`) | true (`Buffer`) |
| payload decoded correctly    | **no** (`undefined`)          | yes           |

Isolating just the connection, on `main`, the client built out of a live foreign-major instance reports:

```
options.host: localhost | options.port: 6379
socket remote: ::1 6379
status: ready
CLIENT INFO -> laddr=172.17.0.6:6379
```

It is `ready`. It is connected. It is connected to the wrong server, and nothing anywhere says so.

## The chain this sits at the bottom of

This is worth spelling out, because the same one-line check has now caused an incident and blocked a release train across three packages.

1. **[adonisjs/redis#77](https://github.com/adonisjs/redis/issues/77) — the original production incident.** `@adonisjs/redis@10.0.1` shipped ioredis 6 in a *patch*. `@adonisjs/cache` passes its `ioConnection` straight down, so the `instanceof` check one layer below started failing, a second connection was opened to `127.0.0.1:6379`, and production logs filled with `connect ECONNREFUSED 127.0.0.1:6379` roughly every 2 seconds. It was resolved by reverting to ioredis 5 and re-shipping ioredis 6 as the `11.0.0` major.
2. **[Julien-R44/bentocache#122](https://github.com/Julien-R44/bentocache/issues/122) — the bug reported at the bentocache layer.** Still open; the reporter correctly diagnosed it as the cross-major `instanceof`.
3. **[adonisjs/cache#18](https://github.com/adonisjs/cache/issues/18) — the downstream symptom.** Because of the above, `@adonisjs/cache` still cannot move to `@adonisjs/redis@11` today, at all.
4. **[Julien-R44/bentocache#123](https://github.com/Julien-R44/bentocache/pull/123) — the sibling PR**, fixing the exact same check one layer up, with the same discriminator. It deliberately did **not** widen bentocache's own `ioredis` peer, and the stated reason is this package: `@boringnode/bus` is a hard dependency of bentocache and peers `ioredis ^5.0.0`, so widening upstream would only produce unmet-peer warnings while the bus still could not accept a version-6 client.
5. **This PR — the last blocking link.** With `#123` applied, a foreign-major client is now correctly *forwarded* to `RedisTransport`, which then fails *its* `instanceof` and re-breaks everything one layer down. I confirmed that live while working on `#123`; it is what sent me here.

So: `@boringnode/bus` → `bentocache` → `@adonisjs/cache`. Fixing it here is what lets bentocache widen its peer, which is what unblocks `@adonisjs/cache`. The other two cannot proceed without this one.

## What changed

### 1. Duck-typing instead of `instanceof`

```ts
function isRedisClient(value: unknown): value is Redis | Cluster {
  if (typeof value !== 'object' || value === null) return false

  const candidate = value as Partial<Redis>

  return typeof candidate.duplicate === 'function' && typeof candidate.sendCommand === 'function'
}
```

Why those two properties, verified against `5.11.1` and `6.0.0` side by side:

* They are on the prototype of **both** `Redis` and `Cluster`, in both majors — all four combinations checked (`v5.Redis`, `v5.Cluster`, `v6.Redis`, `v6.Cluster`).
* Neither name exists in `RedisOptions` or `ClusterOptions` in either major (grepped the shipped `.d.ts`), so a legitimate options object can never be misclassified as a client. That direction matters most: a false positive fails loudly on the first command, a false negative is the silent-localhost bug.
* `constructor.name` is **not** usable here, in case it comes up in review — ioredis builds its clients through a mixin, so instances of both `Redis` and `Cluster` report `EventEmitter` in both majors.

Because the live-client branch is now taken, `useMessageBuffer` from the third argument survives, which fixes the second symptom.

### 2. A tripwire instead of the silent fallback

If a value is *not* recognised as a client but still carries the markers of one — a `status` string, an `options` object and `emit` — we throw `InvalidArgumentsException` rather than dialing localhost. None of those three names are valid ioredis options either, so no legitimate config trips it. The genuine options-object path is untouched: that is the documented API and changing it would be breaking.

This branch is unreachable for every ioredis major that exists today; it only exists so that a *future* shape change degrades into a boot-time error instead of another production incident. **Happy to drop that hunk** if you would rather keep the diff to just the discriminator. (Same offer is on `#123`, so the two stay coherent either way.)

## Peer range: widened to `^5.0.0 || ^6.0.0`

Unlike bentocache, this package *is* in a position to widen — nothing sits below it. So I validated ioredis 6 properly first rather than assuming.

**RESP3 is genuinely negotiated**, not just tolerated: `client.options.protocol === 3` under ioredis 6 (it is `undefined` under 5), and a `HELLO` round trip has the server reporting `proto=3`. Everything below ran under that.

**Full existing suite, unmodified, against `ioredis@6.0.0`: 72 passed, 0 failed** — byte-for-byte the same result as under `5.11.1`, including the real-cluster test (I brought up a three-node cluster on 7000-7002 so it would not be skipped).

**Targeted validation of the whole `RedisTransport` surface** — a standalone harness against Redis 7.2, run under both majors:

| check | ioredis 5.11.1 | ioredis 6.0.0 |
| --- | --- | --- |
| `options.protocol === 3` | no (RESP2) | **yes** |
| server-side `HELLO` reports `proto=3` | no | **yes** |
| publish / subscribe round trip | pass | pass |
| `unsubscribe` stops delivery | pass | pass |
| does not receive its own messages | pass | pass |
| `messageBuffer` delivers a `Buffer` | pass | pass |
| 416-byte payload received **byte-identical** | pass | pass |
| binary payload decodes exactly | pass | pass |
| existing-client `duplicate()` path delivers | pass | pass |
| `duplicate()` path keeps `messageBuffer` | pass | pass |
| `onReconnect` fires after a server restart | pass | pass |
| delivery resumes after reconnect (auto re-subscribe) | pass | pass |

The binary payload was deliberately nasty: a 300-character key, embedded control bytes, multi-byte UTF-8 (`👍`, `日本語`) and a base64 blob of `0x00 0x01 0x02 0xFA 0xFB 0xFC 0xFF` — 416 bytes total, compared with `Buffer.compare` against exactly what was published. Under RESP3 it comes back identical. (For contrast, the non-buffer `message` string path is lossy in *both* majors — no regression there, just a reminder of why `useMessageBuffer` exists.)

**Cluster on RESP3** was checked separately too, against the real three-node cluster: `Cluster` + `useMessageBuffer: true` + a >320-byte multi-byte payload round-trips exactly, and the member nodes report `protocol === 3`.

**One real code change was needed to make the widen honest.** `Redis#duplicate` and `Cluster#duplicate` became generic over the reply mapping in ioredis 6, and the two signatures no longer unify, so `options.duplicate()` on a `Redis | Cluster` union does not compile:

```
src/transports/redis.ts(55,33): error TS2349: This expression is not callable.
  Each member of the union type '(<Override extends Partial<RedisOptions> ...>) | (<OverrideOptions extends ClusterOptionsWithReplyMapping<ReplyMappingMode> ...>)'
  has signatures, but none of those signatures are compatible with each other.
```

This is **pre-existing** — `main` produces the identical error on the identical two lines when typechecked against ioredis 6; my change did not introduce it. The call now goes through a narrow local signature (`duplicateClient`), after which `yarn typecheck` and `yarn build` are clean under **both** majors. Without that, widening the peer would have advertised support this package's own source could not compile against.

`engines.node` is already `>=20.6`, comfortably above ioredis 6's `>=20.0.0`, so no engine change is needed.

The `ioredis` devDependency stays at `^5.11.1`, so CI keeps testing against 5 by default. Alongside it there is now a second, real copy installed under an npm alias, used only by the tests:

```json
"devDependencies": {
  "ioredis-v6": "npm:ioredis@^6.0.0"
}
```

Yarn 4 with the `node-modules` linker resolves the `npm:` protocol natively — the lockfile records it as `"ioredis-v6@npm:ioredis@^6.0.0"` resolving to `ioredis@npm:6.0.0`, and it lands in `node_modules/ioredis-v6` next to `node_modules/ioredis@5.11.1`, so the two are genuinely distinct module instances with distinct classes. No `resolutions`, no patch, no install script.

If you would like a CI matrix that runs the suite against both majors as the *primary* copy, say the word and I will add it — I kept `.github/` out of this PR on purpose.

## Tests

Added to `tests/drivers/redis_transport.spec.ts`. **The cross-major cases use a real ioredis 6 client, not a simulation.** Thanks to the alias above, the test file imports a second, genuine copy of the package:

```ts
import { Redis, Cluster } from 'ioredis'                                    // 5.11.1 — what the package resolves
import { Redis as ForeignRedis, Cluster as ForeignCluster } from 'ioredis-v6' // 6.0.0  — what the app hands us
```

That is exactly the real-world scenario: an application on `@adonisjs/redis@11` (ioredis 6) handing its connection to a bus resolved against ioredis 5. Each cross-major test asserts its own premise at runtime *before* asserting behaviour, so it cannot silently stop covering the bug:

```ts
assert.isFalse((ForeignRedis as unknown) === (Redis as unknown))  // two different constructors
assert.instanceOf(foreignClient, ForeignRedis)                    // a real client of its own copy
assert.isFalse(foreignClient instanceof Redis)                    // ...and not of ours - the trigger condition
assert.isFalse(foreignClient instanceof Cluster)
```

To tell "reused the connection" from "built a new one", the tests record what `duplicate()` returns through an own-property spy that shadows the prototype method — the client stays an instance of its own copy, which is the whole point.

* **a foreign-major `Redis` client is reused** — asserts `duplicate()` was called twice and that the duplicates are real ioredis 6 clients, then proves the message really lands on the configured server by reading it off an independent witness connection bound to the testcontainers port
* **a foreign-major `Cluster` client is reused** — asserts the duplicates are real foreign `Cluster` instances (and *not* `instanceof` our `Cluster`), and that the transport wired `onReconnect` onto the duplicated subscriber
* **`useMessageBuffer` survives on the live-client path** — asserts the subscriber duplicate listens on `messageBuffer` and *not* on `message`, then round-trips a binary payload through Redis and compares the bytes seen on the subscriber with the exact bytes the publisher wrote (`Buffer#equals`)
* **an unrecognisable client-shaped object throws** instead of falling back to localhost
* **a plain options object still builds a new connection** — the guard against the opposite failure, a false positive

Redis is provisioned the way the file already does it, through the existing `@testcontainers/redis` container started in `group.setup` — no second mechanism. The cluster case uses `lazyConnect`, so it needs no server and still runs on CI.

The first four **fail on `main` and pass on this branch**. Verified by reverting only `src/transports/redis.ts` and re-running the file: **13 passed / 4 failed, versus 17 passed here**, and the four failures are precisely those tests. The fifth passes on both by design — it exists so a future tweak to the discriminator cannot start swallowing options objects.

<details>
<summary>Why the <code>Proxy</code> stand-in is gone</summary>

The previous revision simulated the foreign client with a `Proxy` over a null-prototype target. It was shape-faithful and it did fail on `main`, but a real ioredis 6 client is a strictly harder case: it covers everything the `Proxy` covered (different classes, `instanceof` false, working `duplicate()`) plus the parts a facade cannot vouch for — a real prototype chain, a real RESP3 connection, a real `duplicate()` implementation from another major.

The one thing a real client genuinely cannot exercise is the tripwire path — "client-shaped object that is no `ioredis` at all". That case keeps its own test, which uses a plain object literal (`{ status, options, emit }`) and never needed the `Proxy` in the first place. So the helper had no remaining job and was removed rather than kept as dead weight next to the real thing.

</details>

## What I ran

* Full suite on `main`, same machine, cluster up: **67 passed, 0 failed**.
* Full suite on this branch: **72 passed, 0 failed** (the 5 new tests), with `ioredis@5.11.1` as the resolved copy *and* with `ioredis@6.0.0` as the resolved copy (in that second run the alias is a second copy of the same major, which is the duplicated-in-the-tree half of the bug — the tests hold there too).
* `tests/drivers/redis_transport.spec.ts` alone: **17 passed** on the branch, **13 passed / 4 failed** with `src/transports/redis.ts` reverted to the `instanceof` version.
* `yarn lint`, `yarn typecheck` and `yarn build`: clean under both majors. The `duplicateClient` narrow signature is still required with the alias installed — ioredis 6's generic `duplicate` is now in the dependency tree either way.

## What I did *not* validate

* **Sentinel**, and **Valkey** — untouched by this change, but not exercised on ioredis 6 either.
* Only **Redis 7.2**; no other server version, and no TLS.
* The MQTT transport, which this change does not touch.

